### PR TITLE
build(github/workflow): add npm publish automation

### DIFF
--- a/.github/workflow/new-version.yml
+++ b/.github/workflow/new-version.yml
@@ -1,0 +1,30 @@
+name: "New Version Actions (Publish to NPM)"
+
+on:
+  push:
+    branches: # only trigger when a commit was pushed to main
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npm run build
+
+      - id: publish-to-npm
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }} # This token should be added from repo settings
+
+      - id: create-gh-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.publish-to-npm.outputs.version }}
+          release_name: ${{ steps.publish-to-npm.outputs.version }}


### PR DESCRIPTION
- Add a GitHub workflow that automatically publishes a new version to npm when a new commit was pushed to `main`