### PR TITLE
fix: lint-staged-config

### DIFF
--- a/template.json
+++ b/template.json
@@ -40,6 +40,11 @@
       "stylelint-order": "^4.1.0",
       "stylelint-scss": "^3.21.0"
     },
+    "lint-staged": {
+      "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": ["prettier --config ./.prettierrc.js --write"],
+      "src/**/*.{js,jsx,ts,tsx}": ["eslint"],
+      "src/**/*.{css,scss}": ["stylelint"]
+    },
     "eslintConfig": {
       "parser": "@typescript-eslint/parser",
       "plugins": ["react", "react-hooks", "@typescript-eslint", "jsx-a11y"],


### PR DESCRIPTION
In the current package.json there is no lint-staged configuration so husky pre-commit hook does not work as expected and prevent committing. Hence, config for lint-staged added to template.json.